### PR TITLE
Make healing salves consistently give the bowl back

### DIFF
--- a/src/main/java/ms55/roughtweaksrevamped/common/item/HealItem.java
+++ b/src/main/java/ms55/roughtweaksrevamped/common/item/HealItem.java
@@ -13,6 +13,7 @@ import net.minecraft.world.item.*;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.ForgeConfigSpec.DoubleValue;
 import net.minecraftforge.common.ForgeConfigSpec.IntValue;
+import net.minecraftforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -72,9 +73,9 @@ public class HealItem extends Item {
 	public void onUseTick(Level world, LivingEntity player, ItemStack stack, int count) {
 		if (count % HEAL_RATE.get() == 1) {
 			stack.hurtAndBreak(1, player, x -> {
-				x.setItemInHand(player.getUsedItemHand(), RETURN_STACK);
 				x.playSound(SoundEvents.WOOL_PLACE, 1.0F, 0.5F);
-				x.broadcastBreakEvent(player.getUsedItemHand());
+				x.broadcastBreakEvent(x.getUsedItemHand());
+				ItemHandlerHelper.giveItemToPlayer((Player) x, RETURN_STACK);
 			});
 
 			player.heal(HEAL_AMOUNT.get().floatValue());

--- a/src/main/java/ms55/roughtweaksrevamped/common/item/HealItem.java
+++ b/src/main/java/ms55/roughtweaksrevamped/common/item/HealItem.java
@@ -13,7 +13,6 @@ import net.minecraft.world.item.*;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.ForgeConfigSpec.DoubleValue;
 import net.minecraftforge.common.ForgeConfigSpec.IntValue;
-import net.minecraftforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -23,9 +22,9 @@ public class HealItem extends Item {
 	private final IntValue MAX_DAMAGE;
 	private final DoubleValue HEAL_AMOUNT;
 	private final MobEffect EFFECT;
-	private final ItemStack RETURN_STACK;
+	private final Item RETURN_ITEM;
 
-	public HealItem(IntValue useCount, IntValue healRate, DoubleValue healAmount, MobEffect effect, ItemStack returnStack) {
+	public HealItem(IntValue useCount, IntValue healRate, DoubleValue healAmount, MobEffect effect, Item returnItem) {
 		super((new Item.Properties())
                 .stacksTo(1)
 				.durability(10));
@@ -34,7 +33,7 @@ public class HealItem extends Item {
 		this.HEAL_AMOUNT = healAmount;
 		this.MAX_DAMAGE = useCount;
 		this.EFFECT = effect;
-		this.RETURN_STACK = returnStack;
+		this.RETURN_ITEM = returnItem;
 	}
 
 	@Override
@@ -73,9 +72,11 @@ public class HealItem extends Item {
 	public void onUseTick(Level world, LivingEntity player, ItemStack stack, int count) {
 		if (count % HEAL_RATE.get() == 1) {
 			stack.hurtAndBreak(1, player, x -> {
-				x.playSound(SoundEvents.WOOL_PLACE, 1.0F, 0.5F);
-				x.broadcastBreakEvent(x.getUsedItemHand());
-				ItemHandlerHelper.giveItemToPlayer((Player) x, RETURN_STACK);
+				InteractionHand hand = x.getUsedItemHand();
+				x.broadcastBreakEvent(hand);
+
+				if (RETURN_ITEM == null) return;
+				x.setItemInHand(hand, new ItemStack(RETURN_ITEM));
 			});
 
 			player.heal(HEAL_AMOUNT.get().floatValue());

--- a/src/main/java/ms55/roughtweaksrevamped/common/item/ModItems.java
+++ b/src/main/java/ms55/roughtweaksrevamped/common/item/ModItems.java
@@ -20,35 +20,35 @@ public class ModItems {
 				RoughConfig.HEAL_TIME.SALVE_USE_TIME,
 				RoughConfig.HEAL_AMOUNT.SALVE_HEAL_AMOUNT, 
 				null, 
-				new ItemStack(Items.BOWL)));
+				Items.BOWL));
 
 	public static RegistryObject<Item> PLASTER = ITEMS.register(
 		"plaster", () -> new HealItem(RoughConfig.HEAL_COUNT.PLASTER_HEAL_COUNT,
 				RoughConfig.HEAL_TIME.PLASTER_USE_TIME,
 				RoughConfig.HEAL_AMOUNT.PLASTER_HEAL_AMOUNT,
 				null,
-				ItemStack.EMPTY));
+				null));
 
 	public static RegistryObject<Item> BANDAGE = ITEMS.register(
 		"bandage", () -> new HealItem(RoughConfig.HEAL_COUNT.BANDAGE_HEAL_COUNT,
 				RoughConfig.HEAL_TIME.BANDAGE_USE_TIME,
 				RoughConfig.HEAL_AMOUNT.BANDAGE_HEAL_AMOUNT,
 				null,
-				ItemStack.EMPTY));
+				null));
 
 	public static RegistryObject<Item> MEDKIT = ITEMS.register(
 		"medkit", () -> new HealItem(RoughConfig.HEAL_COUNT.MEDKIT_HEAL_COUNT,
 				RoughConfig.HEAL_TIME.MEDKIT_USE_TIME,
 				RoughConfig.HEAL_AMOUNT.MEDKIT_HEAL_AMOUNT,
 				null,
-				ItemStack.EMPTY));
+				null));
 
 	public static RegistryObject<Item> ENCHANTED_MEDKIT = ITEMS.register(
 		"medkit_enchanted", () -> new HealItem(RoughConfig.HEAL_COUNT.MEDKIT_ENCHANTED_HEAL_COUNT,
 				RoughConfig.HEAL_TIME.MEDKIT_ENCHANTED_USE_TIME,
 				RoughConfig.HEAL_AMOUNT.MEDKIT_ENCHANTED_HEAL_AMOUNT,
 				MobEffects.ABSORPTION,
-				ItemStack.EMPTY));
+				null));
 	
 	public static void register(IEventBus eventBus) {
 		ITEMS.register(eventBus);


### PR DESCRIPTION
It was really frustrating that I had to keep making more bowls because it wouldn't give them back to me when the healing salve broke. I thought this was a feature, but looking at the code it seems to be a bug. This PR fixes that.